### PR TITLE
Render blueprint: one‑click deploy for HiveAPI (Docker + Postgres + Redis)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,69 @@
+services:
+  # FastAPI HiveAPI web service
+  - type: web
+    name: hiveapi
+    env: docker
+    region: oregon
+    plan: free
+    dockerfilePath: ./hiveapi/ops/Dockerfile
+    dockerContext: ./hiveapi
+    healthCheckPath: /health
+    numInstances: 1
+    envVars:
+      - key: DB_URL
+        fromDatabase:
+          name: hiveapi-db
+          property: connectionString
+          # Replace psql:// with postgresql+psycopg:// for SQLAlchemy
+          replace:
+            fromPattern: ^postgres://(.*)$
+            toPattern: postgresql+psycopg://$1
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: hiveapi-redis
+          property: connectionString
+      - key: REQUEST_SIGNATURE_REQUIRED
+        value: false
+      - key: JWT_ISSUER
+        value: hiveapi
+      - key: IDEMPOTENCY_TTL_SECONDS
+        value: 600
+      - key: MOVE_TICKET_TTL_SECONDS
+        value: 90
+      - key: LOGOUT_GRACE_SECONDS
+        value: 30
+      - key: SERVER_SWITCH_COOLDOWN_SECONDS
+        value: 180
+      - key: PROMETHEUS_METRICS
+        value: true
+      - key: LOG_LEVEL
+        value: INFO
+      - key: ADMIN_ENABLED
+        value: true
+      - key: ADMIN_USERNAME
+        value: admin
+      - key: ADMIN_PASSWORD
+        generateValue: true
+    postDeployCommand: |
+      cd /app && alembic upgrade head && python -m scripts.seed
+
+  # PostgreSQL database
+  - type: pserv
+    name: hiveapi-db
+    env: docker
+    region: oregon
+    plan: free
+    disk:
+      name: data
+      mountPath: /var/lib/postgresql/data
+      sizeGB: 10
+
+  # Redis instance
+  - type: redis
+    name: hiveapi-redis
+    region: oregon
+    plan: free
+    ipAllowList:
+      - source: 0.0.0.0/0
+        description: everywhere


### PR DESCRIPTION
Adds render.yaml blueprint for one‑click deployment:
- Web service using Dockerfile at hiveapi/ops/Dockerfile
- Managed Postgres and Redis services
- Env var wiring (DB_URL, REDIS_URL) and sensible defaults
- Health check /health
- Post‑deploy command runs Alembic migrations and seeds demo data

Usage:
1) Merge this PR
2) In Render, New → Blueprint → from repo root render.yaml
3) Deploy stack; wait for post‑deploy to finish
4) Open the web service and hit /health, /v1/admin/overview

Notes:
- REQUEST_SIGNATURE_REQUIRED=false by default for public beta testing
- You can set ADMIN_USERNAME/ADMIN_PASSWORD via environment if you want to protect admin endpoints

---
**Factory Session:** https://app.factory.ai/sessions/ISPHD5AStC7NhewFCl5G (created by renoblabs)